### PR TITLE
feat: Add 1px bleed script

### DIFF
--- a/bleed-1px.sh
+++ b/bleed-1px.sh
@@ -1,0 +1,3 @@
+convert -crop 16x16 spritesheet.png sprite.png
+convert sprite-{0..1439}.png -set option:distort:viewport 18x18-1-1 -virtual-pixel Edge -filter point -distort SRT 0 +repage sprite-bleed.png
+montage sprite-bleed-{0..1439}.png -tile 40x36 -geometry 18x18+0+0 -background none spritesheet-bleed.png


### PR DESCRIPTION
Thanks for a wonderful [blogpost](https://charliejwalter.net/spritesheet-bleed/) and script. Saved me a lot of time, and fixed my issue in Unity.

I added a script which I used to add only 1px bleed to each tile. If we compare it to the original bleed script, I only changed:
* `48x48-16-16`  -> `18x18-1-1`
* `48x48+0+0` -> `18x18+0+0`

Slicing in Unity can be done with these settings.
![Unity settings for slicing](https://user-images.githubusercontent.com/656024/99263400-79c82d00-2862-11eb-9348-8955a97d08a5.png)

Please give it a try and see if it works for you as well. Cheers.