### PR TITLE
feat: Modify script to take arguments and only bleed 1px

### DIFF
--- a/bleed-1px.sh
+++ b/bleed-1px.sh
@@ -1,0 +1,3 @@
+convert -crop 16x16 spritesheet.png sprite.png
+convert sprite-{0..1439}.png -set option:distort:viewport 18x18-1-1 -virtual-pixel Edge -filter point -distort SRT 0 +repage sprite-bleed.png
+montage sprite-bleed-{0..1439}.png -tile 40x36 -geometry 18x18+0+0 -background none spritesheet-bleed.png

--- a/bleed-1px.sh
+++ b/bleed-1px.sh
@@ -1,3 +1,0 @@
-convert -crop 16x16 spritesheet.png sprite.png
-convert sprite-{0..1439}.png -set option:distort:viewport 18x18-1-1 -virtual-pixel Edge -filter point -distort SRT 0 +repage sprite-bleed.png
-montage sprite-bleed-{0..1439}.png -tile 40x36 -geometry 18x18+0+0 -background none spritesheet-bleed.png

--- a/bleed2.sh
+++ b/bleed2.sh
@@ -6,10 +6,9 @@ tileSize=$4
 rowCount=$(( spritesheetHeight / tileSize ))
 colCount=$(( spritesheetWidth / tileSize ))
 numTiles=$(( colCount * rowCount ))
-endTileIndex=$(( numTiles - 1))
 tileSizeWithPadding=$((tileSize + 2))
 
-for (( i = 0; i <= endTileIndex; i++ )); do
+for (( i = 0; i < numTiles; i++ )); do
 sprites+=" sprite-$i.png"
 spriteBleeds+=" sprite-bleed-$i.png"
 done

--- a/bleed2.sh
+++ b/bleed2.sh
@@ -1,0 +1,19 @@
+spritesheetName=$1
+spritesheetWidth=$2
+spritesheetHeight=$3
+tileSize=$4
+
+rowCount=$(( spritesheetHeight / tileSize ))
+colCount=$(( spritesheetWidth / tileSize ))
+numTiles=$(( colCount * rowCount ))
+endTileIndex=$(( numTiles - 1))
+tileSizeWithPadding=$((tileSize + 2))
+
+for (( i = 0; i <= endTileIndex; i++ )); do
+sprites+=" sprite-$i.png"
+spriteBleeds+=" sprite-bleed-$i.png"
+done
+
+convert -crop "$tileSize"x"$tileSize" "$spritesheetName" sprite.png
+convert $sprites -set option:distort:viewport "$tileSizeWithPadding"x"$tileSizeWithPadding"-1-1 -virtual-pixel Edge -filter point -distort SRT 0 +repage sprite-bleed.png
+montage $spriteBleeds -tile "$colCount"x"$rowCount" -geometry "$tileSizeWithPadding"x"$tileSizeWithPadding"-0-0 -background none "$spritesheetName"-bleed.png


### PR DESCRIPTION
Thanks again for a wonderful script and blogpost.

I took the time to modify the shell script so you can pass arguments to it, and don't have to worry about modifying the script itself. 
I also made it so that the new spritesheet only bleed 1px.
![unity-slicing](https://user-images.githubusercontent.com/656024/99405451-1f959d80-2930-11eb-912a-1283b4235e5a.png)


* first argument is the name of the spritesheet we want to bleed.
* second argument is SPRITESHEET_WIDTH
* third argument is SPRITESHEET_HEIGHT
* fourth argument is TILE_SIZE

Test it by running `sh bleed2.sh spritesheet.png 640 576 16`
Cheers~